### PR TITLE
Test branch2025

### DIFF
--- a/SoapyBB60C/FindLibBB60.cmake
+++ b/SoapyBB60C/FindLibBB60.cmake
@@ -3,7 +3,7 @@
 ########################################################################
 
 INCLUDE(FindPkgConfig)
-#PKG_CHECK_MODULES(PC_BB60C libbb_api)
+PKG_CHECK_MODULES(PC_BB60C libbb_api)
 
 FIND_PATH(
     BB60C_INCLUDE_DIRS

--- a/SoapyBB60C/FindLibBB60.cmake
+++ b/SoapyBB60C/FindLibBB60.cmake
@@ -8,19 +8,21 @@ PKG_CHECK_MODULES(PC_BB60C libbb_api)
 FIND_PATH(
     BB60C_INCLUDE_DIRS
     NAMES bb_api.h
-    HINTS $ENV{BB60C_DIR}/include
-        ${PC_BB60C_INCLUDEDIR}
-    PATHS /usr/local/include
-          /usr/include
+    HINTS
+        $ENV{BB60C_DIR}/include
+        /usr/local/include/bb60c
+        /usr/local/include
+        /usr/include/bb60c
+        /usr/include
 )
 
 FIND_LIBRARY(
     BB60C_LIBRARIES
     NAMES bb_api
-    HINTS $ENV{BB60C_DIR}/lib
-        ${PC_BB60C_LIBDIR}
-    PATHS /usr/local/lib
-          /usr/lib
+    HINTS
+        $ENV{BB60C_DIR}/lib
+        /usr/local/lib
+        /usr/lib
 )
 
 INCLUDE(FindPackageHandleStandardArgs)

--- a/SoapyBB60C/FindLibBB60.cmake
+++ b/SoapyBB60C/FindLibBB60.cmake
@@ -3,7 +3,7 @@
 ########################################################################
 
 INCLUDE(FindPkgConfig)
-PKG_CHECK_MODULES(PC_BB60C libbb_api)
+#PKG_CHECK_MODULES(PC_BB60C libbb_api)
 
 FIND_PATH(
     BB60C_INCLUDE_DIRS


### PR DESCRIPTION
Updated the  FindLibBB60.cmake to disable the pkg-config section and add the following dirs to find the bb_api.h and bb60c libraries

BB60C Dir
        /usr/local/include/bb60c
        /usr/local/include
        /usr/include/bb60c
        /usr/include

BB60C LIbraries
        /usr/local/lib
        /usr/lib